### PR TITLE
Add h3 to items in feature grid

### DIFF
--- a/src/components/Features.js
+++ b/src/components/Features.js
@@ -17,6 +17,7 @@ const FeatureGrid = ({ gridItems }) => (
               <PreviewCompatibleImage imageInfo={item} />
             </div>
           </div>
+          <h3>{item.heading}</h3>
           <p>{item.text}</p>
         </section>
       </div>


### PR DESCRIPTION
Add h3 to items in feature grid so it is an available field in CMS.